### PR TITLE
fix: Protect against unmounting

### DIFF
--- a/lib/components/FlipCard.js
+++ b/lib/components/FlipCard.js
@@ -41,12 +41,18 @@ export default React.createClass({
   getInitialState() {
     return {
       hasFocus: false,
-      isFlipped: this.props.flipped
+      isFlipped: this.props.flipped,
+      isMounted: false
     };
   },
 
   componentDidMount() {
+    this.setState({isMounted: true});
     this._hideFlippedSide();
+  },
+
+  componentWillUnmount() {
+    this.setState({isMounted: false});
   },
 
   componentWillReceiveProps(newProps) {
@@ -104,7 +110,7 @@ export default React.createClass({
   },
 
   handleFocus() {
-    if (this.props.disabled) return;
+    if (this.props.disabled || !this.state.isMounted) return;
 
     this.setState({
       isFlipped: true
@@ -112,7 +118,7 @@ export default React.createClass({
   },
 
   handleBlur() {
-    if (this.props.disabled) return;
+    if (this.props.disabled || !this.state.isMounted) return;
 
     this.setState({
       isFlipped: false
@@ -165,17 +171,17 @@ export default React.createClass({
   },
 
   _showBothSides() {
-    this.refs.front.style.display = '';
-    this.refs.back.style.display = '';
+    this.refs.front && (this.refs.front.style.display = '');
+    this.refs.back && (this.refs.back.style.display = '');
   },
 
   _hideFlippedSide() {
     // This prevents the flipped side from being tabbable
     if (this.props.disabled) {
       if (this.state.isFlipped) {
-        this.refs.front.style.display = 'none';
+        this.refs.front && (this.refs.front.style.display = 'none');
       } else {
-        this.refs.back.style.display = 'none';
+        this.refs.back && (this.refs.back.style.display = 'none');
       }
     }
   }


### PR DESCRIPTION
When the component is unmounted due to a page transition
multiple errors occur (`setState` on unmounted component and
`this.refs` being empty).
This protects against that.